### PR TITLE
Allow webpack to optimize out redux-logger imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
   },
   "dependencies": {
     "deep-diff": "^0.3.5"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Adding `"sideEffects": false` flags to webpack that this package is safe to remove if no functions were imported from it.  This means that if I do something along the lines of:

```js
import { createLogger } from 'redux-logger'

/* later */

if (process.env.NODE_ENV === 'development') {
  middleware.push(createLogger({ collapsed: true }))
}
```

Then the package will not be included in my bundle when `process.env.NODE_ENV !== 'development'`.  Currently, the variable gets removed from local scope, but Webpack cannot optimize the harmony import since it assumes it has side effects, so it remains in bundle.